### PR TITLE
Update and include hacktest binary

### DIFF
--- a/bin/hacktest
+++ b/bin/hacktest
@@ -1,8 +1,36 @@
 #!/usr/bin/env hhvm
 <?hh
+/*
+ *  Copyright (c) 2018-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
 
 namespace Facebook\HackTest;
 
-require_once(__DIR__.'/../vendor/hh_autoload.php');
+$root = realpath(__DIR__.'/..');
+$found_autoloader = false;
+while (true) {
+  $autoloader = $root.'/vendor/hh_autoload.php';
+  if (file_exists($autoloader)) {
+    $found_autoloader = true;
+    require_once($autoloader);
+    break;
+  }
+  if ($root === '') {
+    break;
+  }
+  $parts = explode('/', $root);
+  array_pop(&$parts);
+  $root = implode('/', $parts);
+}
+
+if (!$found_autoloader) {
+  fprintf(STDERR, "Failed to find autoloader.\n");
+  exit(1);
+}
 
 HackTestCLI::main();

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "hhvm/hacktest",
+  "bin": ["bin/hacktest"],
   "description": "The Hack Test Library",
   "license": "MIT",
   "require-dev": {


### PR DESCRIPTION
Makes it so that users of this framework (i.e. hsl) can run bin/hacktest and find autoloader