### PR TITLE
Remove dependency on definition-finder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     "hhvm": "^3.27.0",
     "hhvm/hhvm-autoload": "^1.6",
     "hhvm/hsl": "^3.26",
-    "facebook/definition-finder": "^2.0",
     "facebook/hh-clilib": "^1.0",
     "facebook/hh-apidoc": "^0.1",
     "hhvm/type-assert": "^3.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd2a83292637a66a9a167fb849e253f1",
+    "content-hash": "8c3d0ae5a1d604cc43e914a69d8ec9f9",
     "packages": [
         {
             "name": "facebook/definition-finder",

--- a/src/Retriever/FileRetriever.php
+++ b/src/Retriever/FileRetriever.php
@@ -10,16 +10,17 @@
 
 namespace Facebook\HackTest;
 
-use type Facebook\DefinitionFinder\FileParser;
 use namespace HH\Lib\Str;
 
 final class FileRetriever {
+  private string $path;
 
-  public function __construct(private string $path = '.') {
+  public function __construct(string $path = '.') {
+    $this->path = \realpath($path);
   }
 
-  public function getTestFiles(): vec<FileParser> {
-    $files = vec[];
+  public function getTestFiles(): keyset<string> {
+    $files = keyset[];
     if (!\is_dir($this->path)) {
       $file = $this->path;
       if (!\is_file($file)) {
@@ -28,7 +29,7 @@ final class FileRetriever {
         );
       }
       if ($this->isTestFile($file)) {
-        return vec[FileParser::fromFile($file)];
+        return keyset[$file];
       }
       throw new InvalidTestFileException(
         Str\format(
@@ -44,7 +45,7 @@ final class FileRetriever {
     foreach ($rii as $file) {
       $filename = $file->getPathname();
       if (!$file->isDir() && $this->isTestFile($filename)) {
-        $files[] = FileParser::fromFile($filename);
+        $files[] = $filename;
       }
     }
 

--- a/tests/clean/retriever/ClassRetrieverTest.php
+++ b/tests/clean/retriever/ClassRetrieverTest.php
@@ -17,20 +17,18 @@ final class ClassRetrieverTest extends HackTestCase {
 
   public function testClassMatchFileName(): void {
     $path = 'tests/clean/hsl/tuple';
-    $file_retriever = new FileRetriever($path);
-    foreach ($file_retriever->getTestFiles() as $file) {
-      $cr = new ClassRetriever($file);
+    $files = (new FileRetriever($path))->getTestFiles();
+    foreach ($files as $file) {
+      $cr = ClassRetriever::forFile($file);
       $classname = $cr->getTestClassName()
         |> Str\split($$, '\\')
         |> C\lastx($$);
-      $filename = $file->getFilename()
+      $filename = $file
         |> Str\split($$, '/')
         |> C\lastx($$)
         |> Str\split($$, '.')
         |> C\firstx($$);
 
-      $parent = $file->getClass($classname)->getParentClassName();
-      expect($parent)->toBeSame(HackTestCase::class);
       expect($classname)->toBeSame($filename);
     }
   }

--- a/tests/clean/retriever/FileRetrieverTest.php
+++ b/tests/clean/retriever/FileRetrieverTest.php
@@ -18,7 +18,7 @@ final class FileRetrieverTest extends HackTestCase {
     $path = 'tests/clean/hsl/tuple';
     $file_retriever = new FileRetriever($path);
     foreach ($file_retriever->getTestFiles() as $file) {
-      expect(\preg_match('/Test(\.php|\.hh)$/', $file->getFilename()) === 1)->toBeTrue();
+      expect(\preg_match('/Test(\.php|\.hh)$/', $file) === 1)->toBeTrue();
     }
   }
 }

--- a/tests/clean/retriever/MethodRetrieverTest.php
+++ b/tests/clean/retriever/MethodRetrieverTest.php
@@ -19,7 +19,7 @@ final class MethodRetrieverTest extends HackTestCase {
     $path = 'tests/clean/hsl/tuple';
     $file_retriever = new FileRetriever($path);
     foreach ($file_retriever->getTestFiles() as $file) {
-      $classname = (new ClassRetriever($file))->getTestClassName();
+      $classname = ClassRetriever::forFile($file)->getTestClassName();
       $test_methods = (new $classname())->getTestMethods();
       foreach ($test_methods as $method) {
         expect(Str\starts_with($method->getName(), 'test'))->toBeTrue();


### PR DESCRIPTION
- simplifies sync setup
- allows usage in HHAST without introducing a circular dependency