### PR TITLE
fix some OSS issues

### DIFF
--- a/src/Framework/HackTestCase.php
+++ b/src/Framework/HackTestCase.php
@@ -36,6 +36,11 @@ class HackTestCase {
     $this->validateTestMethods();
   }
 
+  final public function getTestMethods(
+  ): vec<\ReflectionMethod> {
+    return $this->methods;
+  }
+
   public final async function genRunTests(
     (function(TestResult): void) $write_progress,
   ): Awaitable<dict<string, ?\Throwable>> {
@@ -124,7 +129,8 @@ class HackTestCase {
 
         $tuple_num = 0;
         foreach ($tuples as $tuple) {
-          $tuple as Container<_>;
+          $tuple = vec($tuple);
+          // 3.28+ $tuple as Container<_>;
           $tuple_num++;
           $key = Str\format(
             '%s.%d.%s',
@@ -317,11 +323,15 @@ class HackTestCase {
   }
 
   public static function computeExpectedExceptionCode(mixed $exception_code): ?int {
-    if ($exception_code is int) {
+    if (is_int($exception_code)) {
       return $exception_code;
     }
-    if (PHP\ctype_digit($exception_code)) {
-      return (int)$exception_code;
+    if (!is_string($exception_code)) {
+      return null;
+    }
+    $int = Str\to_int($exception_code);
+    if ($int !== null) {
+      return $int;
     }
 
     // can't handle arbitrary enums for open source
@@ -336,5 +346,4 @@ class HackTestCase {
   public async function afterEachTest(): Awaitable<void> {}
   public static async function beforeFirstTest(): Awaitable<void> {}
   public static async function afterLastTest(): Awaitable<void> {}
-
 }

--- a/src/Runner/HackTestRunner.php
+++ b/src/Runner/HackTestRunner.php
@@ -30,7 +30,7 @@ abstract final class HackTestRunner {
     foreach ($classes as $classname) {
       $test_case = new $classname();
       /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
-      $errors[$classname] = await $test_case->runAsync($writer);
+      $errors[$classname] = await $test_case->runTestsAsync($writer);
     }
     return $errors;
   }

--- a/tests/clean/provider/DataProviderTest.php
+++ b/tests/clean/provider/DataProviderTest.php
@@ -49,7 +49,7 @@ final class DataProviderTest extends HackTestCase {
   }
 
   public function provideSkip(): void {
-    $this->markTestSkipped('This test depends on a data provider that is not ready yet.');
+    self::markTestSkipped('This test depends on a data provider that is not ready yet.');
   }
 
   /** @dataProvider provideSkip */


### PR DESCRIPTION
Summary:
- targetting 3.27 to hopefully get this finished before Wilson leaves: dependent libraries aren't 3.28-clean yet
- there's also an issue with the sync script not having renamed `genRunTests` to `runTestsAsync`. Will investigate separately
- no PHP\

Differential Revision: D9379923
