### PR TITLE
[easy] Suppress new await-in-a-loop linter errors

### DIFF
--- a/src/Framework/HackTest.php
+++ b/src/Framework/HackTest.php
@@ -210,10 +210,12 @@ class HackTest {
             }
           }
           if ($pass) {
+            /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
             await $write_progress(TestResult::PASSED);
             $errors[$key] = null;
           } else {
             $errors[$key] = $e;
+            /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
             await $this->writeErrorAsync($e, $write_progress);
           }
         }


### PR DESCRIPTION
Test Plan: hhast-lint is clean, TravisCI for release builds

Nightly builds were already passing as we don't/can't run hhast-lint on
nighlties, due to FFP change.