### PR TITLE
Add CLI option to only run tests matching a certain pattern

### DIFF
--- a/src/HackTestCLI.php
+++ b/src/HackTestCLI.php
@@ -18,6 +18,7 @@ use namespace HH\Lib\Str;
 final class HackTestCLI extends CLIWithRequiredArguments {
 
   private bool $verbose = false;
+  private ?string $pattern = null;
 
   <<__Override>>
   public static function getHelpTextForRequiredArguments(): vec<string> {
@@ -35,6 +36,14 @@ final class HackTestCLI extends CLIWithRequiredArguments {
         '--verbose',
         '-v',
       ),
+      CLIOptions\with_required_string(
+        ($value) ==> {
+          $this->pattern = $value;
+        },
+        'Only run tests with method names matching this shell pattern', 
+        '--name',
+        '-n', 
+      ),
     ];
   }
 
@@ -42,6 +51,7 @@ final class HackTestCLI extends CLIWithRequiredArguments {
   public async function mainAsync(): Awaitable<int> {
     $errors = await HackTestRunner::runAsync(
       $this->getArguments(),
+      $this->pattern,
       async $result ==> await $this->writeProgressAsync($result),
     );
     $num_tests = 0;

--- a/src/HackTestCLI.php
+++ b/src/HackTestCLI.php
@@ -40,9 +40,9 @@ final class HackTestCLI extends CLIWithRequiredArguments {
         ($value) ==> {
           $this->pattern = $value;
         },
-        'Only run tests with method names matching this shell pattern', 
+        'Only run tests with method names matching this shell pattern',
         '--name',
-        '-n', 
+        '-n',
       ),
     ];
   }
@@ -50,9 +50,11 @@ final class HackTestCLI extends CLIWithRequiredArguments {
   <<__Override>>
   public async function mainAsync(): Awaitable<int> {
     $errors = await HackTestRunner::runAsync(
-      $this->getArguments(),
-      $this->pattern,
-      async $result ==> await $this->writeProgressAsync($result),
+      shape(
+        'paths' => $this->getArguments(),
+        'pattern' => $this->pattern,
+        'writer' => async $result ==> await $this->writeProgressAsync($result),
+      ),
     );
     $num_tests = 0;
     $num_msg = 0;

--- a/src/Runner/HackTestRunner.php
+++ b/src/Runner/HackTestRunner.php
@@ -15,13 +15,15 @@ use namespace HH\Lib\{Keyset, Vec};
 abstract final class HackTestRunner {
 
   public static async function runAsync(
-    vec<string> $paths,
-    ?string $pattern,
-    (function(TestResult): Awaitable<void>) $writer,
+    shape(
+      'paths' => vec<string>,
+      'pattern' => ?string,
+      'writer' => (function(TestResult): Awaitable<void>),
+    ) $options,
   ): Awaitable<dict<string, dict<string, ?\Throwable>>> {
     $errors = dict[];
     $files = keyset[];
-    foreach ($paths as $path) {
+    foreach ($options['paths'] as $path) {
       $files = Keyset\union($files, (new FileRetriever($path))->getTestFiles());
     }
 
@@ -34,7 +36,10 @@ abstract final class HackTestRunner {
       }
       $test_case = new $classname();
       /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
-      $errors[$classname] = await $test_case->runTestsAsync($pattern, $writer);
+      $errors[$classname] = await $test_case->runTestsAsync(
+        $options['pattern'],
+        $options['writer'],
+      );
     }
     return $errors;
   }

--- a/src/Runner/HackTestRunner.php
+++ b/src/Runner/HackTestRunner.php
@@ -16,6 +16,7 @@ abstract final class HackTestRunner {
 
   public static async function runAsync(
     vec<string> $paths,
+    ?string $pattern,
     (function(TestResult): Awaitable<void>) $writer,
   ): Awaitable<dict<string, dict<string, ?\Throwable>>> {
     $errors = dict[];
@@ -33,7 +34,7 @@ abstract final class HackTestRunner {
       }
       $test_case = new $classname();
       /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
-      $errors[$classname] = await $test_case->runTestsAsync($writer);
+      $errors[$classname] = await $test_case->runTestsAsync($pattern, $writer);
     }
     return $errors;
   }

--- a/tests/clean/retriever/MethodRetrieverTest.php
+++ b/tests/clean/retriever/MethodRetrieverTest.php
@@ -11,7 +11,7 @@
 namespace Facebook\HackTest;
 
 use function Facebook\FBExpect\expect;
-use namespace HH\Lib\Str;
+use namespace HH\Lib\{C, Str};
 
 final class MethodRetrieverTest extends HackTest {
 
@@ -24,6 +24,30 @@ final class MethodRetrieverTest extends HackTest {
       $test_methods = (new $classname())->getTestMethods();
       foreach ($test_methods as $method) {
         expect(Str\starts_with($method->getName(), 'test'))->toBeTrue();
+        $type = Str\replace($method->getReturnTypeText(), 'HH\\', '');
+        expect($type === 'void' || $type === 'Awaitable<void>')->toBeTrue();
+        expect($method->isPublic())->toBeTrue();
+      }
+    }
+  }
+
+  public function testValidTestMethodsWithPattern(): void {
+    $path = 'tests/clean/hsl/str/StrIntrospectTest.php';
+    $file_retriever = new FileRetriever($path);
+    foreach ($file_retriever->getTestFiles() as $file) {
+      $classname =
+        ClassRetriever::forFile($file)->getTestClassName() as nonnull;
+      $test_class = new $classname();
+      $all_methods = $test_class->getTestMethods();
+      $filtered_methods = $test_class->getTestMethods('*Compare*');
+
+      expect($all_methods)->toNotBeEmpty();
+      expect($filtered_methods)->toNotBeEmpty();
+      expect(C\count($all_methods))->toBeGreaterThan(C\count($filtered_methods));
+      
+      foreach ($filtered_methods as $method) {
+        expect(Str\starts_with($method->getName(), 'test'))->toBeTrue();
+        expect(Str\contains($method->name, 'Compare'))->toBeTrue();
         $type = Str\replace($method->getReturnTypeText(), 'HH\\', '');
         expect($type === 'void' || $type === 'Awaitable<void>')->toBeTrue();
         expect($method->isPublic())->toBeTrue();


### PR DESCRIPTION
Adding a new CLI argument to the hacktest executable (`--name` or `-n`) which takes an optional [shell pattern](https://www.gnu.org/software/findutils/manual/html_node/find_html/Shell-Pattern-Matching.html) and, if provided, skips test methods that don't match this pattern.

Suggestions for arg name changes are welcome. 