### PR TITLE
Handle ExpectationFailedException correctly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,13 @@
   "bin": ["bin/hacktest"],
   "description": "The Hack Test Library",
   "license": "MIT",
+  "extra": {
+    "branch-alias": {
+      "dev-master": "1.x-dev"
+    }
+  },
   "require-dev": {
-    "facebook/fbexpect": "^2.0.0",
+    "facebook/fbexpect": "^2.3.0",
     "hhvm/hhast": "^3.27"
   },
   "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d22ed86b37f1c2cfbab0f8ba6928ed1",
+    "content-hash": "997b7b9fd929d477cd7c1fce706abd6d",
     "packages": [
         {
             "name": "facebook/hh-clilib",
@@ -238,26 +238,24 @@
         },
         {
             "name": "facebook/fbexpect",
-            "version": "v2.2.0",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/fbexpect.git",
-                "reference": "beff71282013f01609815acd3b8819685112ee4a"
+                "reference": "22b9d59d9ab5e22a07e66fe1d07ba8d0472ae49b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/fbexpect/zipball/beff71282013f01609815acd3b8819685112ee4a",
-                "reference": "beff71282013f01609815acd3b8819685112ee4a",
+                "url": "https://api.github.com/repos/hhvm/fbexpect/zipball/22b9d59d9ab5e22a07e66fe1d07ba8d0472ae49b",
+                "reference": "22b9d59d9ab5e22a07e66fe1d07ba8d0472ae49b",
                 "shasum": ""
             },
             "require": {
                 "facebook/difflib": "^1.0.0",
                 "hhvm": "^3.28",
+                "hhvm/hacktest": "^1.0",
                 "hhvm/hhvm-autoload": "^1.6",
                 "hhvm/hsl": "^3.26"
-            },
-            "require-dev": {
-                "hhvm/hacktest": "^1.0"
             },
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
@@ -265,7 +263,7 @@
                 "MIT"
             ],
             "description": "Unit test helpers for Facebook projects",
-            "time": "2018-10-18T16:44:23+00:00"
+            "time": "2018-11-29T21:04:58+00:00"
         },
         {
             "name": "hhvm/hhast",

--- a/src/HackTestCLI.php
+++ b/src/HackTestCLI.php
@@ -71,14 +71,12 @@ final class HackTestCLI extends CLIWithRequiredArguments {
           $output .=
             Str\format("\n\n%d) %s::%s\n", $num_msg, $class, $test_params);
         }
-        if ($err instanceof SkippedTestException) {
+        if ($err is SkippedTestException) {
           $num_skipped++;
           $output .= 'Skipped: '.$err->getMessage();
           continue;
-        } else if (
-          \is_a($err, 'PHPUnit\\Framework\\ExpectationFailedException', true) ||
-          \is_a($err, 'PHPUnit_Framework_ExpectationFailedException', true)
-        ) {
+        }
+        if ($err is ExpectationFailedException) {
           $num_failed++;
         }
         if ($this->verbose) {


### PR DESCRIPTION
- migrate from instanceof to is while I'm here
- remove support for PHPUnit exceptions
- add support for HackTests' own exceptions

This makes the test run clean.

Test plan:

Ran the tests, they pass now. Previously failed as it was indicating
ERROR rather than FAILURE, as is expected for unrecognized exceptions
being thrown.