### PR TITLE
ignore platform reqs so allow installation of incompatible hhast

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -2,7 +2,7 @@
 set -ex
 hhvm --version
 
-composer install
+composer install --ignore-platform-reqs
 
 hh_client
 


### PR DESCRIPTION
HHAST pins against 3.y.*, but we test against both nighlties and release
if testing against nightlies, we don't run hhast, but we're not able to
tell the package manager that that means we don't need it