### PR TITLE
Add much more verbose output

### DIFF
--- a/src/enum/TestProgressEvent.php
+++ b/src/enum/TestProgressEvent.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2018-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HackTest;
+
+enum TestProgressEvent: int {
+  CALLING_DATAPROVIDERS = 0;
+  STARTING = 1;
+  FINISHED = 2;
+}


### PR DESCRIPTION
Example:

```
HHVM\UserDocumentation\Tests\APINavDataTest> starting...
  ::testNamespacedDefinitionName> starting...
PASS
  ::testNamespacedDefinitionName> ...complete.
  ::testNamespacedDefinitionURL> starting...
PASS
  ::testNamespacedDefinitionURL> ...complete.
HHVM\UserDocumentation\Tests\APINavDataTest> ...complete.
HHVM\UserDocumentation\Tests\APIPagesTest> starting...
  ::testAPIPage> calling data providers...
  ::testAPIPage[1]> starting...
PASS
  ::testAPIPage[1]> ...complete.
  ::testAPIPage[2]> starting...
PASS
  ::testAPIPage[2]> ...complete.
  ::testAPIPage[3]> starting...
PASS
```