### PR TITLE
Add `--filter-classes`, `--filter-methods`, and `--filter-groups`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: required
 language: generic
 services: docker
 env:
-- HHVM_VERSION=4.1-latest
+- HHVM_VERSION=4.6-latest
+- HHVM_VERSION=4.8-latest
 - HHVM_VERSION=latest
 - HHVM_VERSION=nightly
 install:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "hhvm/hhast": "^4.0"
   },
   "require": {
-    "hhvm": "^4.1",
+    "hhvm": "^4.6",
     "hhvm/hhvm-autoload": "^2.0.2",
     "hhvm/hsl": "^4.0",
     "facebook/hh-clilib": "^2.0.0",

--- a/src/Framework/HackTest.hack
+++ b/src/Framework/HackTest.hack
@@ -39,7 +39,13 @@ class HackTest {
     return $this->methods;
   }
 
+  const type TFilters = shape(
+    'methods' => (function(string): string),
+    // TODO: dataproviders
+  );
+
   public final async function runTestsAsync(
+    (function(string):bool) $method_filter,
     (function(
       classname<HackTest>,
       ?string,
@@ -54,6 +60,9 @@ class HackTest {
 
     foreach ($this->methods as $method) {
       $to_run = vec[];
+      if (!$method_filter($method->getName())) {
+        continue;
+      }
 
       $this->clearExpectedException();
       $exception = $method->getAttribute('ExpectedException');

--- a/src/Framework/HackTest.hack
+++ b/src/Framework/HackTest.hack
@@ -45,7 +45,7 @@ class HackTest {
   );
 
   public final async function runTestsAsync(
-    (function(string):bool) $method_filter,
+    (function(\ReflectionMethod): bool) $method_filter,
     (function(
       classname<HackTest>,
       ?string,
@@ -60,7 +60,7 @@ class HackTest {
 
     foreach ($this->methods as $method) {
       $to_run = vec[];
-      if (!$method_filter($method->getName())) {
+      if (!$method_filter($method)) {
         continue;
       }
 
@@ -99,7 +99,7 @@ class HackTest {
             ),
           );
         }
-      /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
+        /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
         await $progress_writer(
           static::class,
           $method_name,
@@ -149,7 +149,7 @@ class HackTest {
           $to_run[] = tuple(
             $method_name,
             $idx,
-          /* HH_IGNORE_ERROR[2011] this is unsafe */
+            /* HH_IGNORE_ERROR[2011] this is unsafe */
             () ==> $this->$method_name(...$tuple),
           );
         }
@@ -326,8 +326,9 @@ class HackTest {
   ): void {
     $this->expectedException = $exception;
     $this->expectedExceptionMessage = $exception_message;
-    $this->expectedExceptionCode =
-      static::computeExpectedExceptionCode($exception_code);
+    $this->expectedExceptionCode = static::computeExpectedExceptionCode(
+      $exception_code,
+    );
   }
 
   private function clearExpectedException(): void {

--- a/src/Framework/TestGroup.hack
+++ b/src/Framework/TestGroup.hack
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2018-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HackTest;
+
+use namespace HH\Lib\C;
+
+/** Mark a test as a member of a particular group.
+ *
+ *
+ * @example
+ *
+ *     <<TestGroup('quick')>>
+ *     public function testFoo(): void {
+ *     }
+ */
+final class TestGroup implements \HH\MethodAttribute {
+  private keyset<string> $groups;
+
+  public function __construct(
+    string ...$groups
+   ) {
+    $this->groups = keyset($groups);
+  }
+
+  public function contains(string $group): bool {
+    return C\contains_key($this->groups, $group);
+  }
+}

--- a/src/Runner/HackTestRunner.hack
+++ b/src/Runner/HackTestRunner.hack
@@ -12,9 +12,13 @@ namespace Facebook\HackTest;
 use namespace HH\Lib\{Keyset, Vec};
 
 abstract final class HackTestRunner {
+  const type TMethodFilter = (function(
+    classname<HackTest>,
+    \ReflectionMethod,
+  ): bool);
   const type TFilters = shape(
     'classes' => (function(classname<HackTest>): bool),
-    'methods' => (function(classname<HackTest>, string): bool),
+    'methods' => this::TMethodFilter,
   );
 
   public static async function runAsync(

--- a/tests/clean/exit/ExitCodeTest.php
+++ b/tests/clean/exit/ExitCodeTest.php
@@ -41,4 +41,32 @@ final class ExitCodeTest extends HackTest {
     $terminal = new Terminal($stdin, $stdout, $stderr);
     return new HackTestCLI($argv, $terminal);
   }
+
+  public async function testFiltering(): Awaitable<void> {
+    expect(await self::makeCLI(vec['', 'tests/mixed'])->mainAsync())->toBeSame(
+      ExitCode::FAILURE,
+    );
+    expect(await self::makeCLI(vec['', 'tests/mixed', '--filter-methods=*Fail'])
+      ->mainAsync())->toBeSame(ExitCode::FAILURE);
+    expect(await self::makeCLI(vec['', 'tests/mixed', '--filter-methods=*Pass'])
+      ->mainAsync())->toBeSame(ExitCode::SUCCESS);
+    expect(await self::makeCLI(vec['', 'tests/mixed', '--filter-groups=passes'])
+      ->mainAsync())->toBeSame(ExitCode::SUCCESS);
+    expect(
+      await self::makeCLI(vec['', 'tests/mixed', '--filter-groups=fails'])
+        ->mainAsync(),
+    )->toBeSame(ExitCode::FAILURE);
+    expect(
+      await self::makeCLI(vec['', 'tests/mixed', '--filter-groups=passes,junk'])
+        ->mainAsync(),
+    )->toBeSame(ExitCode::SUCCESS);
+    expect(
+      await self::makeCLI(vec['', 'tests/mixed', '--filter-groups=fails,junk'])
+        ->mainAsync(),
+    )->toBeSame(ExitCode::FAILURE);
+    expect(await self::makeCLI(
+      vec['', 'tests/mixed', '--filter-groups=passes,fails'],
+    )
+      ->mainAsync())->toBeSame(ExitCode::FAILURE);
+  }
 }

--- a/tests/mixed/SomeFailTest.hack
+++ b/tests/mixed/SomeFailTest.hack
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HackTest;
+
+use function Facebook\FBExpect\expect;
+
+final class SomeFailTest extends HackTest {
+  <<TestGroup('fails')>>
+  public function testFail(): void {
+    expect(true)->toBeFalse();
+  }
+
+  <<TestGroup('passes')>>
+  public function testPass(): void {
+    expect(true)->toBeTrue();
+  }
+}


### PR DESCRIPTION
- `-classes` and `-methods` take glob patterns
- `-groups` takes a comma-separated list of `<<TestGroup('foo')>>` foo's

This replaces #54