### PR TITLE
Support running hack-test in repo-auth mode.

### DIFF
--- a/src/Retriever/CacheFile.hack
+++ b/src/Retriever/CacheFile.hack
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2018-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HackTest\_Private;
+
+/**
+ * Codegen Hack files to store data.
+ *
+ * Using Hack files so that we don't need real files or the static content
+ * cache, which is unavailable in repo-authoritative mode.
+ */
+final class CacheFile {
+  public function __construct(private string $path) {
+  }
+
+  private function getFunctionName(): string {
+    return 'hacktest_cache_'.\bin2hex(\sodium_crypto_generichash($this->path));
+  }
+
+  public function store(mixed $x): void {
+    \file_put_contents(
+      $this->path,
+      'function '.
+      $this->getFunctionName().
+      "(): mixed {\n".
+      'return '.
+      \var_export($x, true).
+      ";\n}\n",
+    );
+  }
+
+  public function fetch(): mixed {
+    require_once($this->path);
+    $fun = $this->getFunctionName();
+    return /* HH_FIXME[4009] */ $fun();
+  }
+}


### PR DESCRIPTION
Various forms of file access (glob, realpath) and other functions
(facts_parse) are unavailable in repo-authoritative mode.

Additionally, the static content cache is unavailable in
repo-authoritative CLI mode.

For that reason, add `hacktest --prepare-repo-auth` that does some
fairly disgusting codegen.

Tested with the HSL repository:

```
$ REPO_DIR="$(mktemp -d)"
$ vendor/bin/hacktest --prepare-repo-auth tests/
$ hhvm --hphp --target hhbc \
    -l 3 \
    --ffile vendor/bin/hacktest \
    --module src \
    --module vendor \
    --module tests \
    --ffile vendor/bin/hacktest \
    --output-dir "$REPO_DIR"
$ cd $REPO_DIR
$ hhvm   --no-config   -d hhvm.repo.authoritative=true   -d "hhvm.repo.central.path=${REPO_DIR}/hhvm.hhbc"     vendor/bin/hacktest tests/
...........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Summary: 1227 test(s), 1227 passed, 0 failed, 0 skipped, 0 error(s).
````