### PR TITLE
support repo mode using AutoloadMap

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -17,3 +17,19 @@ bin/hacktest tests/clean/
 if !(hhvm --version | grep -q -- -dev); then
   vendor/bin/hhast-lint
 fi
+
+# also run tests in repo-authoritative mode
+REPO_DIR=$(mktemp -d)
+
+hhvm --hphp --target hhbc -l 3 \
+  --module bin \
+  --module src \
+  --module tests \
+  --module vendor \
+  --ffile bin/hacktest \
+  --output-dir $REPO_DIR
+
+hhvm --no-config \
+  -d hhvm.repo.authoritative=true \
+  -d hhvm.repo.central.path=$REPO_DIR/hhvm.hhbc \
+  bin/hacktest tests/clean/

--- a/bin/hacktest.hack
+++ b/bin/hacktest.hack
@@ -12,22 +12,20 @@ namespace Facebook\HackTest;
 
 <<__EntryPoint>>
 async function hack_test_main_async(): Awaitable<noreturn> {
-  $root = \realpath(__DIR__.'/..');
+  $root = \dirname(__DIR__);
   $found_autoloader = false;
   while (true) {
-    $autoloader = $root.'/vendor/autoload.hack';
-    if (\file_exists($autoloader)) {
+    try {
+      require_once($root.'/vendor/autoload.hack');
       $found_autoloader = true;
-      require_once($autoloader);
       \Facebook\AutoloadMap\initialize();
       break;
+    } catch (\Error $_) {
     }
-    if ($root === '') {
+    if ($root === '/') {
       break;
     }
-    $parts = \explode('/', $root);
-    \array_pop(&$parts);
-    $root = \implode('/', $parts);
+    $root = \dirname($root);
   }
 
   if (!$found_autoloader) {


### PR DESCRIPTION
Alternative to https://github.com/hhvm/hacktest/pull/84.

This doesn't require running a codegen script, but it does introduce a dependency on [hhvm/hhvm-autoload](https://github.com/hhvm/hhvm-autoload) (i.e. wouldn't be able to locate tests in projects using a different autoloader).