### PR TITLE
Pretty-print context on failures

### DIFF
--- a/src/HackTestCLI.hack
+++ b/src/HackTestCLI.hack
@@ -87,8 +87,8 @@ final class HackTestCLI extends CLIWithRequiredArguments {
     $cf = $this->classFilter;
     $mf = $this->methodFilter;
     $output = $this->verbose
-      ? new _Private\VerboseCLIOutput()
-      : new _Private\ConciseCLIOutput();
+      ? new _Private\VerboseCLIOutput($this->getTerminal())
+      : new _Private\ConciseCLIOutput($this->getTerminal());
     $stdout = $this->getStdout();
 
     await HackTestRunner::runAsync(

--- a/src/_Private/CLIOutputHandler.hack
+++ b/src/_Private/CLIOutputHandler.hack
@@ -120,6 +120,11 @@ abstract class CLIOutputHandler {
     \Throwable $ex,
     string $file,
   ): ?string {
+    if (!\file_exists($file)) {
+      // Possibly running in repo-authoritative mode
+      return null;
+    }
+
     $frame = $ex->getTrace()
       |> Vec\filter(
         $$,

--- a/src/_Private/ConciseCLIOutput.hack
+++ b/src/_Private/ConciseCLIOutput.hack
@@ -11,12 +11,13 @@
 
 namespace Facebook\HackTest\_Private;
 
-use namespace HH\Lib\{Str, Vec};
+use namespace HH\Lib\{Math, Str, Vec};
 use namespace HH\Lib\Experimental\IO;
 use namespace Facebook\HackTest;
 use type Facebook\HackTest\TestResult;
 
 final class ConciseCLIOutput extends CLIOutputHandler {
+
   <<__Override>>
   protected async function writeProgressImplAsync(
     <<__AcceptDisposable>> IO\WriteHandle $handle,
@@ -63,14 +64,16 @@ final class ConciseCLIOutput extends CLIOutputHandler {
         $message = 'Skipped: '.$ex->getMessage();
       } else if ($event is HackTest\FileProgressEvent) {
         $file = $event->getPath();
-        $trace = $ex->getTraceAsString()
+
+        $context = $this->getPrettyContext($ex, $file) ??
+          $ex->getTraceAsString()
           |> Str\split($$, '#')
           |> Vec\filter($$, $line ==> Str\contains($line, $file))
           |> Vec\map($$, $line ==> Str\strip_prefix($line, '  '))
           |> Str\join($$, "\n");
 
-        if ($trace !== '') {
-          $message .= "\n\n".$trace;
+        if ($context !== '') {
+          $message .= "\n\n".$context;
         }
       }
       await $handle->writeAsync($header.$message);

--- a/src/_Private/ConciseCLIOutput.hack
+++ b/src/_Private/ConciseCLIOutput.hack
@@ -11,7 +11,7 @@
 
 namespace Facebook\HackTest\_Private;
 
-use namespace HH\Lib\{Math, Str, Vec};
+use namespace HH\Lib\{Str, Vec};
 use namespace HH\Lib\Experimental\IO;
 use namespace Facebook\HackTest;
 use type Facebook\HackTest\TestResult;

--- a/src/_Private/VerboseCLIOutput.hack
+++ b/src/_Private/VerboseCLIOutput.hack
@@ -102,6 +102,13 @@ final class VerboseCLIOutput extends CLIOutputHandler {
           $message .= "\n\nPrevious exception:\n\n";
         }
       }
+      if ($event is HackTest\FileProgressEvent) {
+        $file = $event->getPath();
+        $context = $this->getPrettyContext($ex, $file);
+        if ($context is nonnull) {
+          $message .= "\n\n".$context;
+        }
+      }
       await $handle->writeAsync($header.$message);
     }
   }


### PR DESCRIPTION
Concise first, then verbose:

refs #18

![Screen Shot 2019-11-01 at 4 08 52 PM](https://user-images.githubusercontent.com/360927/68061481-574c8b80-fcc2-11e9-8c33-435f54a60acb.png)
