### PR TITLE
[easy] fix typo in --verbose dataprovider messages

### DIFF
--- a/src/_Private/VerboseCLIOutput.hack
+++ b/src/_Private/VerboseCLIOutput.hack
@@ -62,7 +62,7 @@ final class VerboseCLIOutput extends CLIOutputHandler {
       if ($e is HackTest\TestInstanceProgressEvent) {
         $dp = $e->getDataProviderRow();
         if ($dp is nonnull) {
-          $scope .= '['.(string)$dp[0].'];';
+          $scope .= '['.(string)$dp[0].']';
         }
       }
     } else if ($e is HackTest\ClassProgressEvent) {


### PR DESCRIPTION
```
fredemmott@fredemmott-fb hacktest % bin/hacktest tests/clean/hsl/keyset/KeysetCombineTest.php --verbose
  ::testUnion> calling data providers...
  ::testUnion[0];> starting...
PASS
  ::testUnion[0];> ...complete.
  ::testUnion[1];> starting...
PASS
  ::testUnion[1];> ...complete.

Summary: 2 test(s), 2 passed, 0 failed, 0 skipped, 0 error(s).
fredemmott@fredemmott-fb hacktest % git stash pop
On branch master
Your branch is up-to-date with 'origin/master'.
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   src/_Private/VerboseCLIOutput.hack

no changes added to commit (use "git add" and/or "git commit -a")
Dropped refs/stah@{0} (e5ea9658d5039d704e05446085c084765bd80baf)
fredemmott@fredemmott-fb hacktest % bin/hacktest tests/clean/hsl/keyset/KeysetCombineTest.php --verbose
  ::testUnion> calling data providers...
  ::testUnion[0]> starting...
PASS
  ::testUnion[0]> ...complete.
  ::testUnion[1]> starting...
PASS
  ::testUnion[1]> ...complete.

Summary: 2 test(s), 2 passed, 0 failed, 0 skipped, 0 error(s).
```

note extra colon before `>` in first run