### PR TITLE
Use getAttributeClass to reflect on DataProviders

### DIFF
--- a/src/Framework/HackTest.hack
+++ b/src/Framework/HackTest.hack
@@ -86,9 +86,9 @@ class HackTest {
       }
 
       $providers = vec[];
-      $provider = $method->getAttribute('DataProvider');
-      if ($provider !== null) {
-        $providers[] = (string)C\onlyx($provider);
+      $provider = $method->getAttributeClass(DataProvider::class)?->provider;
+      if ($provider is nonnull) {
+        $providers[] = $provider;
       }
 
       $method_name = $method->getName();


### PR DESCRIPTION
This is needed for https://github.com/hhvm/hhast/pull/276.
It relies on HackTest not accepting an unnamespaced DataProvider attr.