### PR TITLE
[easy] make VerboseCLIOutput forward compatible with future HSL IO ch…

### DIFF
--- a/src/_Private/VerboseCLIOutput.hack
+++ b/src/_Private/VerboseCLIOutput.hack
@@ -83,7 +83,8 @@ final class VerboseCLIOutput extends CLIOutputHandler {
       $header = $this->getMessageHeaderForErrorDetails($error_id, $event);
 
       if ($event is HackTest\TestSkippedProgressEvent) {
-        return await $handle->writeAsync($header.'Skipped: '.$ex->getMessage());
+        await $handle->writeAsync($header.'Skipped: '.$ex->getMessage());
+        return;
       }
 
       $it = $ex;


### PR DESCRIPTION
…ange

HSL IO is changing `writeAsync()` to return `Awaitable<int>`, but the
function here is `Awaitable<void>` - `return await` is no longer
compatible.

Tangentially, I'm a little surprised that explicit return values are OK
in `Awaitable` functions :/