### PR TITLE
Use `writeAllAsync` instead of `writeAsync` to avoid truncated output

### DIFF
--- a/src/_Private/ConciseCLIOutput.hack
+++ b/src/_Private/ConciseCLIOutput.hack
@@ -75,7 +75,7 @@ final class ConciseCLIOutput extends CLIOutputHandler {
           $message .= "\n\n".$context;
         }
       }
-      await $handle->writeAsync($header.$message);
+      await $handle->writeAllAsync($header.$message);
     }
   }
 }

--- a/src/_Private/VerboseCLIOutput.hack
+++ b/src/_Private/VerboseCLIOutput.hack
@@ -70,7 +70,7 @@ final class VerboseCLIOutput extends CLIOutputHandler {
       $scope = $e->getPath();
     }
 
-    await $handle->writeAsync($scope.'> '.$message."\n");
+    await $handle->writeAllAsync($scope.'> '.$message."\n");
   }
 
   private async function writeFailureDetailsAsync(


### PR DESCRIPTION
HSL IO change for this was quite a while back; `writeAsync` will wait
until a write is possible, then do exactly one write, which could result
in partial success.
