### PR TITLE
Add aliasses for noreturn functions with nothing

### DIFF
--- a/src/Framework/HackTest.hack
+++ b/src/Framework/HackTest.hack
@@ -52,11 +52,8 @@ class HackTest {
     (function(\ReflectionMethod): bool) $method_filter,
     (function(ProgressEvent): Awaitable<void>) $progress_callback,
   ): Awaitable<void> {
-    $progress = new _Private\Progress(
-      $progress_callback,
-      $this->filename,
-      static::class,
-    );
+    $progress =
+      new _Private\Progress($progress_callback, $this->filename, static::class);
 
     await static::beforeFirstTestAsync();
     await using new _Private\OnScopeExitAsync(
@@ -262,14 +259,58 @@ class HackTest {
     }
   }
 
+  /**
+   * Preferred over markTestSkipped(), because the typechecker considers
+   * code past markTestSkipped() to be unreachable. This triggers inference
+   * bugs when dealing with coeffects @see tests/ShowCoeffectViolationTest.php.
+   * If you ever want to make your test not be skipped anymore, the code will
+   * be reachable again, which may reveal previously hidden errors introduced
+   * by code changes made whilst the test was skipped.
+   *
+   * You can use `return static::markAsSkipped('skipping');` to match the old
+   * `static::markTestSkipped('skipping')` behavior.
+   */
+  public static final function markAsSkipped(string $message): nothing {
+    self::markTestSkipped($message);
+  }
+
+  /**
+   * Code below this invocation will become unreachable for the typechecker.
+   * This reduces the strength of typechecking and may raise bogus type errors.
+   * @see markAsSkipped()
+   */
   public static final function markTestSkipped(string $message): noreturn {
     throw new SkippedTestException($message);
   }
 
+  /**
+   * Preferred over markTestIncomplete(), @see markAsSkipped() for rationale.
+   */
+  public static function markAsIncomplete(string $message): nothing {
+    self::markTestIncomplete($message);
+  }
+
+  /**
+   * Code below this invocation will become unreachable for the typechecker.
+   * This reduces the strength of typechecking and may raise bogus type errors.
+   * @see markAsIncomplete()
+   */
   public static function markTestIncomplete(string $message): noreturn {
     throw new SkippedTestException($message);
   }
 
+  /**
+   * Preferred over fail(), @see markAsSkipped() for rationale.
+   */
+  public static function markAsFailed(string $message = ''): nothing {
+    self::fail($message);
+  }
+
+  /**
+   * Code below this invocation will become unreachable for the typechecker.
+   * This reduces the strength of typechecking and may raise bogus type errors.
+   * @see markAsFailed()
+   */
   public static final function fail(string $message = ''): noreturn {
     throw new \RuntimeException($message);
   }

--- a/src/Framework/HackTest.hack
+++ b/src/Framework/HackTest.hack
@@ -276,7 +276,7 @@ class HackTest {
 
   /**
    * Code below this invocation will become unreachable for the typechecker.
-   * This reduces the strength of typechecking and may raise bogus type errors.
+   * This reduces the strength of typechecking and may raise baseless type errors.
    * @see markAsSkipped()
    */
   public static final function markTestSkipped(string $message): noreturn {
@@ -292,7 +292,7 @@ class HackTest {
 
   /**
    * Code below this invocation will become unreachable for the typechecker.
-   * This reduces the strength of typechecking and may raise bogus type errors.
+   * This reduces the strength of typechecking and may raise baseless type errors.
    * @see markAsIncomplete()
    */
   public static function markTestIncomplete(string $message): noreturn {
@@ -308,7 +308,7 @@ class HackTest {
 
   /**
    * Code below this invocation will become unreachable for the typechecker.
-   * This reduces the strength of typechecking and may raise bogus type errors.
+   * This reduces the strength of typechecking and may raise baseless type errors.
    * @see markAsFailed()
    */
   public static final function fail(string $message = ''): noreturn {

--- a/src/Framework/HackTest.hack
+++ b/src/Framework/HackTest.hack
@@ -286,7 +286,7 @@ class HackTest {
   /**
    * Preferred over markTestIncomplete(), @see markAsSkipped() for rationale.
    */
-  public static function markAsIncomplete(string $message): nothing {
+  public static final function markAsIncomplete(string $message): nothing {
     self::markTestIncomplete($message);
   }
 
@@ -302,7 +302,7 @@ class HackTest {
   /**
    * Preferred over fail(), @see markAsSkipped() for rationale.
    */
-  public static function markAsFailed(string $message = ''): nothing {
+  public static final function markAsFailed(string $message = ''): nothing {
     self::fail($message);
   }
 
@@ -322,9 +322,8 @@ class HackTest {
   ): void {
     $this->expectedException = $exception;
     $this->expectedExceptionMessage = $exception_message;
-    $this->expectedExceptionCode = static::computeExpectedExceptionCode(
-      $exception_code,
-    );
+    $this->expectedExceptionCode =
+      static::computeExpectedExceptionCode($exception_code);
   }
 
   private function clearExpectedException(): void {

--- a/tests/dirty/ShowCoeffectViolationTest.php
+++ b/tests/dirty/ShowCoeffectViolationTest.php
@@ -17,14 +17,14 @@ final class ShowCoeffectViolationTest extends HackTest\HackTest {
     -> This is the method with where type constraints [2]
     -> Expected a function that requires the capability set {AccessGlobals, IO, ImplicitPolicyLocal, RxLocal, System, WriteProperty} [3]
     -> But got a function that requires nothing [4]
-    
+
     tests/SomeTest.hack:7:23
           5 |   public function testShowCoeffectViolation(): void {
           6 |     self::markTestSkipped('This test is pointless');
     [1]   7 |     expect(() ==> 3)->toThrow(\Exception::class);
           8 |   }
           9 | }
-    
+
     vendor/facebook/fbexpect/src/ExpectObj.hack:569:19
         567 |    * the awaitable will be awaited.
         568 |    *
@@ -36,10 +36,10 @@ final class ShowCoeffectViolationTest extends HackTest\HackTest {
     [3] 574 |   ): TException where T = (function(): TRet) {
         575 |     $msg = \vsprintf($msg ?? '', $args);
         576 |     $exception = $this->tryCallReturnException($exception_class);
-    
+
     .:0:0
     [4]   0 | No source found
-    
+
     1 error found.
     */
   public function testShowCoeffectViolation(): void {

--- a/tests/dirty/ShowCoeffectViolationTest.php
+++ b/tests/dirty/ShowCoeffectViolationTest.php
@@ -1,0 +1,55 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+use namespace Facebook\HackTest;
+use function Facebook\FBExpect\expect;
+
+final class ShowCoeffectViolationTest extends HackTest\HackTest {
+  /*
+    Typing[4323] A where type constraint is violated here [1]
+    -> This is the method with where type constraints [2]
+    -> Expected a function that requires the capability set {AccessGlobals, IO, ImplicitPolicyLocal, RxLocal, System, WriteProperty} [3]
+    -> But got a function that requires nothing [4]
+    
+    tests/SomeTest.hack:7:23
+          5 |   public function testShowCoeffectViolation(): void {
+          6 |     self::markTestSkipped('This test is pointless');
+    [1]   7 |     expect(() ==> 3)->toThrow(\Exception::class);
+          8 |   }
+          9 | }
+    
+    vendor/facebook/fbexpect/src/ExpectObj.hack:569:19
+        567 |    * the awaitable will be awaited.
+        568 |    *
+    [2] 569 |   public function toThrow<TException as \Throwable, TRet>(
+        570 |     classname<TException> $exception_class,
+        571 |     ?string $expected_exception_message = null,
+        572 |     ?string $msg = null,
+        573 |     mixed ...$args
+    [3] 574 |   ): TException where T = (function(): TRet) {
+        575 |     $msg = \vsprintf($msg ?? '', $args);
+        576 |     $exception = $this->tryCallReturnException($exception_class);
+    
+    .:0:0
+    [4]   0 | No source found
+    
+    1 error found.
+    */
+  public function testShowCoeffectViolation(): void {
+    self::markTestSkipped('This test is pointless');
+    /* HH_FIXME[4323] The error shown above. */
+    expect(() ==> 3)->toThrow(\Exception::class);
+  }
+
+  public function testWithoutCoeffectViolation(): void {
+    self::markAsSkipped('This test is pointless');
+    expect(() ==> 3)->toThrow(\Exception::class);
+  }
+}


### PR DESCRIPTION
The noreturn variants affect the typechecker in interesting ways.
This is often surpricing and breaks tests using expect($it)->toThrow().
I have seen the following workarounds in the wild.
```
if ('always true') {
  self::markTestSkipped('skipping');
}

(): void ==> {
  self::markTestSkipped('skipping');
}();
```