### PR TITLE
Require hhvm 4.128 and support autoloading with ext_watchman

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 tests/ export-ignore
 .hhconfig export-ignore
+.hhvmconfig.hdf export-ignore

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu, macos ]
         hhvm:
-          - '4.102'
+          - '4.128'
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/.hhvmconfig.hdf
+++ b/.hhvmconfig.hdf
@@ -1,0 +1,3 @@
+Autoload {
+  Query = {"expression": ["allof", ["type", "f"], ["suffix", ["anyof", "hack", "php"]], ["not",["anyof",["dirname",".var"],["dirname",".git"]]]]}
+}

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,11 @@
   },
   "require-dev": {
     "facebook/fbexpect": "^2.8.1",
+    "hhvm/hhvm-autoload": "^2.0.2|^3.0",
     "hhvm/hhast": "^4.0"
   },
   "require": {
-    "hhvm": "^4.102",
-    "hhvm/hhvm-autoload": "^2.0.2|^3.0",
-    "hhvm/hsl-experimental": "^4.58.0rc1",
-    "hhvm/hsl-io": "^0.2.0|^0.3.0",
+    "hhvm": "^4.128",
     "facebook/hh-clilib": "^2.5.0rc1",
     "hhvm/type-assert": "^3.0|^4.0"
   }

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,10 @@
     "hhvm": "^4.128",
     "facebook/hh-clilib": "^2.5.0rc1",
     "hhvm/type-assert": "^3.0|^4.0"
+  },
+  "config": {
+    "allow-plugins": {
+      "hhvm/hhvm-autoload": true
+    }
   }
 }

--- a/hh_autoload.json
+++ b/hh_autoload.json
@@ -5,5 +5,6 @@
   "devRoots": [
     "tests/"
   ],
-  "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler"
+  "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler",
+  "useFactsIfAvailable": true
 }

--- a/hhast-lint.json
+++ b/hhast-lint.json
@@ -4,5 +4,11 @@
   "disabledLinters": [
     "Facebook\\HHAST\\UseStatementWithAsLinter",
     "Facebook\\HHAST\\Linters\\UseStatementWithAsLinter"
+  ],
+  "overrides": [
+    {
+      "patterns": ["tests/clean/hsl/*"],
+      "disableAllLinters": true
+    }
   ]
 }

--- a/src/Framework/HackTest.hack
+++ b/src/Framework/HackTest.hack
@@ -59,9 +59,7 @@ class HackTest {
     );
 
     await static::beforeFirstTestAsync();
-    await using new _Private\OnScopeExitAsync(
-      async () ==> await static::afterLastTestAsync(),
-    );
+    await using new _Private\OnScopeExitAsync(static::afterLastTestAsync<>);
 
     foreach ($this->methods as $method) {
       $to_run = vec[];

--- a/src/Retriever/ClassRetriever.hack
+++ b/src/Retriever/ClassRetriever.hack
@@ -19,9 +19,9 @@ use type Facebook\HackTest\_Private\{
 
 final class ClassRetriever {
   const type TFacts = shape(
-    'types' => varray<shape(
+    'types' => vec<shape(
       'name' => string,
-      'baseTypes' => varray<string>,
+      'baseTypes' => vec<string>,
       'kindOf' => string,
       ...
     )>,
@@ -57,7 +57,7 @@ final class ClassRetriever {
 
     $all_facts = \HH\facts_parse(
       /* root = */ '/',
-      varray($paths),
+      vec($paths),
       /* force_hh = */ false,
       /* multithreaded = */ true,
     );


### PR DESCRIPTION
The hsl is always built-in.
ext_watchman and HH\Facts are always available.
varray eq vec and darray eq dict is always true.
All legacy arrays have been replaced with Hack arrays.