### PR TITLE
Replace --ffile flag with --inputs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu ]
         hhvm:
-          - '4.128'
+          - '4.153'
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,7 +39,7 @@ jobs:
             --module src \
             --module tests \
             --module vendor \
-            --inputs bin/hacktest
+            --inputs bin/hacktest \
             --exclude-dir vendor/bin \
             --output-dir ${{ steps.create-repo-dir.outputs.path }}
       - name: Run tests in repo-authoritative mode

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,6 +35,7 @@ jobs:
           # Exclude vendor/bin/ to work around issue in HHVM 4.62
           # https://github.com/facebook/hhvm/issues/8719
           hhvm --hphp -l 3 \
+            --format hhas \
             --module bin \
             --module src \
             --module tests \

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,6 +39,7 @@ jobs:
             --module src \
             --module tests \
             --module vendor \
+            --inputs bin/hacktest
             --exclude-dir vendor/bin \
             --output-dir ${{ steps.create-repo-dir.outputs.path }}
       - name: Run tests in repo-authoritative mode

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,6 @@ jobs:
           # Exclude vendor/bin/ to work around issue in HHVM 4.62
           # https://github.com/facebook/hhvm/issues/8719
           hhvm --hphp -l 3 \
-            --format binary \
             --module bin \
             --module src \
             --module tests \

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
           # Exclude vendor/bin/ to work around issue in HHVM 4.62
           # https://github.com/facebook/hhvm/issues/8719
           hhvm --hphp -l 3 \
-            --format text \
+            --format binary \
             --module bin \
             --module src \
             --module tests \

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,7 +39,6 @@ jobs:
             --module src \
             --module tests \
             --module vendor \
-            --ffile bin/hacktest \
             --exclude-dir vendor/bin \
             --output-dir ${{ steps.create-repo-dir.outputs.path }}
       - name: Run tests in repo-authoritative mode

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
           # Exclude vendor/bin/ to work around issue in HHVM 4.62
           # https://github.com/facebook/hhvm/issues/8719
           hhvm --hphp -l 3 \
-            --format hhas \
+            --format text \
             --module bin \
             --module src \
             --module tests \

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu ]
         hhvm:
-          - '4.153'
+          - '4.128'
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest
@@ -39,7 +39,7 @@ jobs:
             --module src \
             --module tests \
             --module vendor \
-            --inputs bin/hacktest \
+            ${{ matrix.hhvm == '4.128' && '--ffile' || '--inputs' }} bin/hacktest \
             --exclude-dir vendor/bin \
             --output-dir ${{ steps.create-repo-dir.outputs.path }}
       - name: Run tests in repo-authoritative mode


### PR DESCRIPTION
This PR peplaces --ffile flag with --inputs, because `--ffile` has been removed since https://github.com/facebook/hhvm/commit/e1e755ab76e47f2cefd6c3b9aeda0819c4d3cbef .  