### PR TITLE
Unit test for dataproviders with period in key

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,12 +11,10 @@ jobs:
       # Run tests on all OS's and HHVM versions, even if one fails
       fail-fast: false
       matrix:
-        os: [ ubuntu ]
+        os: [ ubuntu-20.04 ]
         hhvm:
           - '4.168'
-          - latest
-          - nightly
-    runs-on: ${{matrix.os}}-latest
+    runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2
       - name: Create branch for version alias

--- a/tests/clean/provider/DataProviderTest.php
+++ b/tests/clean/provider/DataProviderTest.php
@@ -34,6 +34,15 @@ final class DataProviderTest extends HackTest {
     expect(Str\join($traversable, '-'))->toBeSame('the-quick-brown-fox-1');
   }
 
+  public function provideWithPeriod()[]: dict<string, (string)> {
+    return dict['per.iod' => tuple('str')];
+  }
+
+  <<DataProvider('provideWithPeriod')>>
+  public function testPeriodInKey(string $v): void {
+    expect($v)->toEqual('str');
+  }
+
   public function provideMultipleArgs(): vec<(int, int)> {
     return vec[
       tuple(1, 2),

--- a/tests/dirty/DataProviderWithPeriodInKeyTest.php
+++ b/tests/dirty/DataProviderWithPeriodInKeyTest.php
@@ -10,7 +10,6 @@
 
 use function Facebook\FBExpect\expect;
 use type Facebook\HackTest\{DataProvider, HackTest};
-use namespace HH\Lib\Str;
 
 // @oss-disable: <<Oncalls('hack')>>
 final class DataProviderWithPeriodInKeyTest extends HackTest {

--- a/tests/dirty/DataProviderWithPeriodInKeyTest.php
+++ b/tests/dirty/DataProviderWithPeriodInKeyTest.php
@@ -1,0 +1,25 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\{DataProvider, HackTest};
+use namespace HH\Lib\Str;
+
+// @oss-disable: <<Oncalls('hack')>>
+final class DataProviderWithPeriodInKeyTest extends HackTest {
+  public function provideWithPeriod()[]: dict<string, (string)> {
+    return dict['per.iod' => tuple('str')];
+  }
+
+  <<DataProvider('provideWithPeriod')>>
+  public function testPeriodInKey(string $v): void {
+    expect($v)->toNotEqual('str');
+  }
+}


### PR DESCRIPTION
fixes #80 

Fixes:
 - Write a unit test for providers with periods in the key